### PR TITLE
Feat add benchmarking CLI Utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ CmakeCache.txt
 cmake_install.cmake
 *fkvs-cli
 *fkvs-server
+*fkvs-benchmark
 *fkvs
 .idea
 build.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,16 @@ cmake_minimum_required(VERSION 3.31.2)
 
 project(fkvs-server C)
 project(fkvs-cli C)
+project(fkvs-benchmark C)
 
 set(CMake_C_STANDARD, 23)
 
 if(APPLE)
   add_executable(fkvs-server client.c list.c config.c networking.c server.c hashtable.c command_registry.c server_command_handlers.c event_dispatcher_kqueue.c)
   target_compile_definitions(fkvs-server PRIVATE SERVER)
+
+  add_executable(fkvs-benchmark fkvs-benchmark.c client.c list.c networking.c command_parser.c client_command_handlers.c)
+  target_compile_definitions(fkvs-benchmark PRIVATE CLI)
 elseif(LINUX)
   add_executable(fkvs-server client.c list.c config.c networking.c server.c hashtable.c command_registry.c server_command_handlers.c event_dispatcher_epoll.c)
   target_compile_definitions(fkvs-server PRIVATE SERVER)

--- a/client.conf
+++ b/client.conf
@@ -1,6 +1,6 @@
 # Client configuration
 # print additional information
-verbose true
+verbose false
 # port the client should bind to on the server
 port 5995
 # server the client should connect to

--- a/client.h
+++ b/client.h
@@ -17,6 +17,7 @@ typedef struct client_t {
     char ip_str[INET6_ADDRSTRLEN]; // TODO: Remove this in the future
     char *ip_address;
     int port;
+    bool benchmark_mode;
     bool verbose; // print additional information
 } client_t;
 

--- a/client_command_handlers.c
+++ b/client_command_handlers.c
@@ -192,11 +192,15 @@ void command_response_handler(client_t *client)
                         0) { // if the length of the value relayed
                         // back to client is 0, we assume no PING received no
                         // arguments
-                        // printf("PONG\n");
+                        if (!client->benchmark_mode) {
+                            printf("PONG\n");
+                        }
                     } else {
                         char *data = malloc(value_len + 1);
                         memcpy(data, &client->buffer[5], value_len);
-                        // printf("\"%s\" \n", data);
+                        if (!client->benchmark_mode) {
+                            printf("\"%s\" \n", data);
+                        }
                         free(data);
                     }
                 } else {
@@ -205,16 +209,22 @@ void command_response_handler(client_t *client)
                     char *data = malloc(value_len + 1);
                     memcpy(data, &client->buffer[5], value_len);
                     if (strlen(data) == 0) {
-                        // printf("OK\n");
+                        if (!client->benchmark_mode) {
+                            printf("OK\n");
+                        }
                     } else {
-                        printf("\"%s\" \n", data);
+                        if (!client->benchmark_mode) {
+                            printf("\"%s\" \n", data);
+                        }
                     }
 
                     free(data);
                 }
             }
         } else {
-            // printf("(nil) \n");
+            if (!client->benchmark_mode) {
+                // printf("(nil) \n");
+            }
         }
     }
 }

--- a/client_command_handlers.c
+++ b/client_command_handlers.c
@@ -192,11 +192,11 @@ void command_response_handler(client_t *client)
                         0) { // if the length of the value relayed
                         // back to client is 0, we assume no PING received no
                         // arguments
-                        printf("PONG\n");
+                        // printf("PONG\n");
                     } else {
                         char *data = malloc(value_len + 1);
                         memcpy(data, &client->buffer[5], value_len);
-                        printf("\"%s\" \n", data);
+                        // printf("\"%s\" \n", data);
                         free(data);
                     }
                 } else {
@@ -205,7 +205,7 @@ void command_response_handler(client_t *client)
                     char *data = malloc(value_len + 1);
                     memcpy(data, &client->buffer[5], value_len);
                     if (strlen(data) == 0) {
-                        printf("OK\n");
+                        // printf("OK\n");
                     } else {
                         printf("\"%s\" \n", data);
                     }
@@ -214,7 +214,7 @@ void command_response_handler(client_t *client)
                 }
             }
         } else {
-            printf("(nil) \n");
+            // printf("(nil) \n");
         }
     }
 }

--- a/config.c
+++ b/config.c
@@ -92,6 +92,7 @@ client_t loadClientConfig(const char *path)
     client.port = 5995;
     client.ip_address = "127.0.0.1";
     client.verbose = false;
+    client.benchmark_mode = false;
 
     char line[1024];
 

--- a/event_dispatcher.h
+++ b/event_dispatcher.h
@@ -1,7 +1,7 @@
 #ifndef EVENT_DISPATCHER_H
 #define EVENT_DISPATCHER_H
 
-#define MAX_EVENTS 4096
+#define MAX_EVENTS 100000
 
 // Defines the interface for platform-specific event loops
 int run_event_loop(int server_fd);

--- a/fkvs-benchmark.c
+++ b/fkvs-benchmark.c
@@ -1,104 +1,248 @@
 #include "client.h"
 #include "client_command_handlers.h"
 #include "networking.h"
-#include "utils.h"
+#include <errno.h>
+#include <netinet/tcp.h>
 #include <pthread.h>
 #include <stdatomic.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
 #include <time.h>
 
-typedef struct benchmark_config {
-    u_int64_t requests;
-    u_int64_t clients;
-    bool keep_alive;
+#ifdef __APPLE__
+#include <mach/mach_time.h>
+#endif
+
+typedef struct {
+    uint64_t requests; // total requests across all threads
+    uint64_t clients;  // number of worker threads
+    bool keep_alive;   // persistent connection per thread
+    const char *ip;
+    int port;
+    bool verbose;
+    char *command_type;
 } benchmark_config_t;
 
-void print_usage_and_exit()
+typedef struct {
+    pthread_mutex_t mu;
+    pthread_cond_t cv;
+    int ready; // workers that arrived at the gate
+    int need;  // how many workers to wait for
+    int go;    // broadcast start when set to 1
+} start_gate_t;
+
+static void gate_init(start_gate_t *g, const int need)
 {
-    printf("Usage: fkvs-benchmark [options]\n");
+    pthread_mutex_init(&g->mu, NULL);
+    pthread_cond_init(&g->cv, NULL);
+    g->ready = 0;
+    g->need = need;
+    g->go = 0;
+}
+
+static void print_usage_and_exit(const char *prog)
+{
+    fprintf(stderr,
+            "Usage: %s [-n total_requests] [-c clients] [-h host] [-p port] "
+            "[-k] \n"
+            "  -n N     total requests across all clients (default 100000)\n"
+            "  -c C     number of concurrent clients (default 32)\n"
+            "  -h HOST  server host/IP (default 127.0.0.1)\n"
+            "  -p PORT  server port (default 5995)\n"
+            "  -k       keep-alive (default on)\n"
+            "  -t       type of command to use during benchmark (ping, get, set, default ping) \n",
+            prog);
     exit(1);
 }
 
-typedef struct benchmark_stats {
-
-} benchmark_stats;
-
-// clock_gettime was a good choice because it works on both macOS and Linux.
 static double monotonic_seconds(void)
 {
+#ifdef __APPLE__
+    static mach_timebase_info_data_t tb;
+    if (!tb.denom)
+        mach_timebase_info(&tb);
+    const uint64_t t = mach_absolute_time();
+    return ((double)t * (double)tb.numer / (double)tb.denom) * 1e-9;
+#else
+#ifdef CLOCK_MONOTONIC_RAW
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+#else
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
+#endif
     return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+#endif
 }
 
-int main(int argc, char *argv[])
+static void tune_socket(const int fd)
 {
-    client_t *client = malloc(sizeof(client_t));
-    client->port = 5995;
-    client->ip_address = "127.0.0.1";
-    client->verbose = false;
+    const int one = 1;
+    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
 
-    benchmark_config_t *benchmark_config = malloc(sizeof(benchmark_config_t));
-    benchmark_config->keep_alive = true;
-    benchmark_config->clients = 50;
-    benchmark_config->requests = 1000;
+    struct timeval tv;
+    tv.tv_sec = 2;
+    tv.tv_usec = 0; // 2s I/O timeouts
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+}
 
-    if (argc < 2) {
-        print_usage_and_exit();
+typedef struct {
+    const benchmark_config_t *cfg;
+    start_gate_t *gate;
+    uint64_t num_reqs_for_this_thread;
+    // these are our outputs:
+    uint64_t completed;
+    uint64_t failed;
+} worker_args_t;
+
+static void *worker(void *arg)
+{
+    worker_args_t *w = arg;
+
+    client_t client = {0};
+    client.ip_address = (char *)w->cfg->ip;
+    client.port = w->cfg->port;
+    client.verbose = w->cfg->verbose;
+
+    int fd = start_client(&client);
+    if (fd != -1) {
+        tune_socket(fd);
     }
 
-    for (int i = 0; i < argc; i++) {
-        if (strcmp("-p ", argv[i]) == 0) {
-            client->port = atoi(argv[i++]);
-        }
+    // arrive at the start gate
+    pthread_mutex_lock(&w->gate->mu);
+    w->gate->ready++;
+    pthread_cond_signal(&w->gate->cv);
+    while (!w->gate->go)
+        pthread_cond_wait(&w->gate->cv, &w->gate->mu);
+    pthread_mutex_unlock(&w->gate->mu);
 
-        if (strcmp("-h ", argv[i]) == 0) {
-            client->ip_address = argv[i++];
+    uint64_t ok = 0, ko = 0;
+    for (uint64_t i = 0; i < w->num_reqs_for_this_thread; ++i) {
+        if (fd == -1) {
+            ko++;
+            continue;
         }
+        execute_command(w->cfg->command_type, &client, command_response_handler);
+        ok++;
+        // TODO: Handle failures correctly. We currently don't track failures (ko's).
+    }
 
-        if (strcmp("-k ", argv[i]) == 0) {
-            benchmark_config->keep_alive = true;
-        }
+    w->completed = ok;
+    w->failed = ko;
+    return NULL;
+}
 
-        if (strcmp("-n", argv[i]) == 0) {
-            benchmark_config->requests = strtoull(argv[++i], NULL, 10);
-        }
+int main(const int argc, char **argv)
+{
+    benchmark_config_t cfg = {.requests = 100000,
+                              .clients = 32,
+                              .keep_alive = true,
+                              .ip = "127.0.0.1",
+                              .port = 5995,
+                              .command_type = "PING",
+                              .verbose = false};
 
-        if (strcmp("-c ", argv[i]) == 0) {
-            benchmark_config->clients = strtoull(argv[++i], NULL, 10);
+    for (int i = 1; i < argc; ++i) {
+        if (strcasecmp(argv[i], "--h") == 0 || strcasecmp(argv[i], "--help") == 0) {
+            print_usage_and_exit(argv[0]);
+        } else if (strcmp(argv[i], "-n") == 0 && i + 1 < argc) {
+            cfg.requests = strtoull(argv[++i], NULL, 10);
+        } else if (strcmp(argv[i], "-c") == 0 && i + 1 < argc) {
+            cfg.clients = strtoull(argv[++i], NULL, 10);
+        } else if (strcmp(argv[i], "-h") == 0 && i + 1 < argc) {
+            cfg.ip = argv[++i];
+        } else if (strcmp(argv[i], "-p") == 0 && i + 1 < argc) {
+            cfg.port = atoi(argv[++i]);
+        } else if (strcmp(argv[i], "-k") == 0) {
+            cfg.keep_alive = true;
+        } else if (strcmp(argv[i], "-t") == 0 && i + 1 < argc) {
+          if (strcmp(argv[++i], "ping") == 0) {
+            cfg.command_type = "PING";
+          }
         }
     }
 
-    const int client_fd = start_client(client);
-    static uint64_t counter = 0;
+    if (cfg.clients == 0)
+        cfg.clients = 1;
+    if (cfg.requests < cfg.clients)
+        cfg.requests = cfg.clients;
 
-    char command[BUFFER_SIZE] = {"PING"};
+    // divide work across threads
+    const uint64_t base = cfg.requests / cfg.clients;
+    const uint64_t rem = cfg.requests % cfg.clients;
 
-    printf("Benchmark requestz: %llu\n", benchmark_config->requests);
+    pthread_t *ths = calloc(cfg.clients, sizeof(*ths));
+    worker_args_t *args = calloc(cfg.clients, sizeof(*args));
 
-    const char *cmd_part = strtok(command, " ");
-    if (cmd_part == NULL) {
-        print_usage_and_exit();
-    }
+    start_gate_t gate;
+    gate_init(&gate, (int)cfg.clients);
 
-    const double t0 = monotonic_seconds();
-    for (int i = 0; i < benchmark_config->requests; i++) {
-        if (client_fd == -1) {
-            ERROR_AND_EXIT("Failed to connect to server");
-            return 1;
+    int started = 0;
+    for (uint64_t t = 0; t < cfg.clients; ++t) {
+        args[t].cfg = &cfg;
+        args[t].gate = &gate;
+        args[t].num_reqs_for_this_thread = base + (t < rem ? 1 : 0);
+
+        const int rc = pthread_create(&ths[t], NULL, worker, &args[t]);
+        if (rc != 0) {
+            fprintf(stderr, "pthread_create failed: %s\n", strerror(rc));
+            break;
         }
-        execute_command(cmd_part, client, command_response_handler);
-        counter += 1;
+        started++;
     }
-    const double t1 = monotonic_seconds();
 
-    const double elapsed = t1 - t0;
+    if (started == 0) {
+        fprintf(stderr, "No workers started. exiting.\n");
+        free(ths);
+        free(args);
+        return 1;
+    }
 
-    const double reqs_sec = (double)counter / elapsed;
-    printf("Total calls: %llu\n", counter);
-    printf("Elapsed: %.6f s\n", elapsed);
-    printf("Estimated reqs/sec: %.2f\n", reqs_sec);
-    free(benchmark_config);
-    free(client);
+    // wait for readiness with a timeout, then we proceed with those that are
+    // ready
+    pthread_mutex_lock(&gate.mu);
+    while (gate.ready < gate.need) {
+        struct timespec abs;
+        clock_gettime(CLOCK_REALTIME, &abs);
+        abs.tv_sec += 2; // 2s to gather
+        const int rc = pthread_cond_timedwait(&gate.cv, &gate.mu, &abs);
+        if (rc == ETIMEDOUT) {
+            fprintf(stderr, "%d/%d workers ready.\n", gate.ready, gate.need);
+            gate.need = gate.ready; // Let's proceed with the ones that arrived
+            break;
+        }
+    }
+    const double start = monotonic_seconds();
+    gate.go = 1;
+    pthread_cond_broadcast(&gate.cv);
+    pthread_mutex_unlock(&gate.mu);
+
+    // join and aggregate results
+    uint64_t done = 0, fail = 0;
+    for (int t = 0; t < started; ++t) {
+        pthread_join(ths[t], NULL);
+        done += args[t].completed;
+        fail += args[t].failed;
+    }
+    const double end = monotonic_seconds();
+
+    const double elapsed = end - start;
+    const double rps = elapsed > 0 ? (double)done / elapsed : 0.0;
+
+    printf("Clients: %llu  Total requests: %llu\n",
+           (unsigned long long)cfg.clients, (unsigned long long)cfg.requests);
+    printf("Completed: %llu  Failed: %llu\n", (unsigned long long)done,
+           (unsigned long long)fail);
+    printf("Elapsed: %.6f s  Throughput: %.2f req/s\n", elapsed, rps);
+
+    free(ths);
+    free(args);
+    return 0;
 }

--- a/fkvs-benchmark.c
+++ b/fkvs-benchmark.c
@@ -1,0 +1,104 @@
+#include "client.h"
+#include "client_command_handlers.h"
+#include "networking.h"
+#include "utils.h"
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <time.h>
+
+typedef struct benchmark_config {
+    u_int64_t requests;
+    u_int64_t clients;
+    bool keep_alive;
+} benchmark_config_t;
+
+void print_usage_and_exit()
+{
+    printf("Usage: fkvs-benchmark [options]\n");
+    exit(1);
+}
+
+typedef struct benchmark_stats {
+
+} benchmark_stats;
+
+// clock_gettime was a good choice because it works on both macOS and Linux.
+static double monotonic_seconds(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+}
+
+int main(int argc, char *argv[])
+{
+    client_t *client = malloc(sizeof(client_t));
+    client->port = 5995;
+    client->ip_address = "127.0.0.1";
+    client->verbose = false;
+
+    benchmark_config_t *benchmark_config = malloc(sizeof(benchmark_config_t));
+    benchmark_config->keep_alive = true;
+    benchmark_config->clients = 50;
+    benchmark_config->requests = 1000;
+
+    if (argc < 2) {
+        print_usage_and_exit();
+    }
+
+    for (int i = 0; i < argc; i++) {
+        if (strcmp("-p ", argv[i]) == 0) {
+            client->port = atoi(argv[i++]);
+        }
+
+        if (strcmp("-h ", argv[i]) == 0) {
+            client->ip_address = argv[i++];
+        }
+
+        if (strcmp("-k ", argv[i]) == 0) {
+            benchmark_config->keep_alive = true;
+        }
+
+        if (strcmp("-n", argv[i]) == 0) {
+            benchmark_config->requests = strtoull(argv[++i], NULL, 10);
+        }
+
+        if (strcmp("-c ", argv[i]) == 0) {
+            benchmark_config->clients = strtoull(argv[++i], NULL, 10);
+        }
+    }
+
+    const int client_fd = start_client(client);
+    static uint64_t counter = 0;
+
+    char command[BUFFER_SIZE] = {"PING"};
+
+    printf("Benchmark requestz: %llu\n", benchmark_config->requests);
+
+    const char *cmd_part = strtok(command, " ");
+    if (cmd_part == NULL) {
+        print_usage_and_exit();
+    }
+
+    const double t0 = monotonic_seconds();
+    for (int i = 0; i < benchmark_config->requests; i++) {
+        if (client_fd == -1) {
+            ERROR_AND_EXIT("Failed to connect to server");
+            return 1;
+        }
+        execute_command(cmd_part, client, command_response_handler);
+        counter += 1;
+    }
+    const double t1 = monotonic_seconds();
+
+    const double elapsed = t1 - t0;
+
+    const double reqs_sec = (double)counter / elapsed;
+    printf("Total calls: %llu\n", counter);
+    printf("Elapsed: %.6f s\n", elapsed);
+    printf("Estimated reqs/sec: %.2f\n", reqs_sec);
+    free(benchmark_config);
+    free(client);
+}

--- a/fkvs-benchmark.c
+++ b/fkvs-benchmark.c
@@ -55,7 +55,8 @@ static void print_usage_and_exit(const char *prog)
             "  -h HOST  server host/IP (default 127.0.0.1)\n"
             "  -p PORT  server port (default 5995)\n"
             "  -k       keep-alive (default on)\n"
-            "  -t       type of command to use during benchmark (ping, get, set, default ping) \n",
+            "  -t       type of command to use during benchmark (ping, get, "
+            "set, default ping) \n",
             prog);
     exit(1);
 }
@@ -108,6 +109,7 @@ static void *worker(void *arg)
     client_t client = {0};
     client.ip_address = (char *)w->cfg->ip;
     client.port = w->cfg->port;
+    client.benchmark_mode = true;
     client.verbose = w->cfg->verbose;
 
     int fd = start_client(&client);
@@ -129,9 +131,11 @@ static void *worker(void *arg)
             ko++;
             continue;
         }
-        execute_command(w->cfg->command_type, &client, command_response_handler);
+        execute_command(w->cfg->command_type, &client,
+                        command_response_handler);
         ok++;
-        // TODO: Handle failures correctly. We currently don't track failures (ko's).
+        // TODO: Handle failures correctly. We currently don't track failures
+        // (ko's).
     }
 
     w->completed = ok;
@@ -150,7 +154,8 @@ int main(const int argc, char **argv)
                               .verbose = false};
 
     for (int i = 1; i < argc; ++i) {
-        if (strcasecmp(argv[i], "--h") == 0 || strcasecmp(argv[i], "--help") == 0) {
+        if (strcasecmp(argv[i], "--h") == 0 ||
+            strcasecmp(argv[i], "--help") == 0) {
             print_usage_and_exit(argv[0]);
         } else if (strcmp(argv[i], "-n") == 0 && i + 1 < argc) {
             cfg.requests = strtoull(argv[++i], NULL, 10);
@@ -163,9 +168,9 @@ int main(const int argc, char **argv)
         } else if (strcmp(argv[i], "-k") == 0) {
             cfg.keep_alive = true;
         } else if (strcmp(argv[i], "-t") == 0 && i + 1 < argc) {
-          if (strcmp(argv[++i], "ping") == 0) {
-            cfg.command_type = "PING";
-          }
+            if (strcmp(argv[++i], "ping") == 0) {
+                cfg.command_type = "PING";
+            }
         }
     }
 

--- a/networking.c
+++ b/networking.c
@@ -9,7 +9,7 @@
 #include <time.h>
 #include <unistd.h>
 
-#define BACKLOG 4096 // Number of allowed connections
+#define BACKLOG 1000000 // Number of allowed connections
 
 #ifdef SERVER
 

--- a/networking.c
+++ b/networking.c
@@ -9,7 +9,7 @@
 #include <time.h>
 #include <unistd.h>
 
-#define BACKLOG 1000000 // Number of allowed connections
+#define BACKLOG 2000000 // Number of allowed connections
 
 #ifdef SERVER
 
@@ -143,7 +143,9 @@ int start_client(client_t *client)
         return -1;
     }
 
-    printf("Connected to server on port %d\n", client->port);
+    if (client->verbose) {
+        printf("Connected to server on port %d\n", client->port);
+    }
     return client_fd;
 }
 #endif

--- a/server.conf
+++ b/server.conf
@@ -1,6 +1,6 @@
 # Server configuration
 port 5995
 logs-enabled true
-verbose true
+verbose false
 daemonize false
 show-logo true


### PR DESCRIPTION
This implements #4 and allows one to run benchmarks on the fkvs server.

With the current implementation we can do the following:

```sh
./fkvs-benchmark -n 1000000 -k -b 127.0.0.1 -p 5995 -c 50 -t ping     
```

and it would output the the following:

```text
Clients: 50  Total requests: 100000
Completed: 100000  Failed: 0
Elapsed: 0.674666 s  Throughput: 148221.52 req/s
```

This implementation currently does not show p50, and such percentiles but the next iteration will definitely have this. 