### PR TITLE
fix: INCR command being interpreted as INCR_BY.

### DIFF
--- a/client_command_handlers.c
+++ b/client_command_handlers.c
@@ -56,7 +56,7 @@ void cmd_set(const command_args_t args, void (*response_cb)(client_t *client))
     }
 }
 
-void cmd_inc(const command_args_t args, void (*response_cb)(client_t *client))
+void cmd_incr(const command_args_t args, void (*response_cb)(client_t *client))
 {
     if (!strcasecmp(args.cmd, "INCR")) {
         const char *key = strtok(NULL, " ");
@@ -165,7 +165,7 @@ void cmd_unknown(const command_args_t args,
 
 const cmd_t command_table[] = {
     {"cmd_set", cmd_set},   {"cmd_get", cmd_get},
-    {"cmd_inc", cmd_inc},   {"cmd_incr_by", cmd_incr_by},
+    {"cmd_incr", cmd_incr}, {"cmd_incr_by", cmd_incr_by},
     {"cmd_ping", cmd_ping}, {"cmd_unknown", cmd_unknown}};
 
 void execute_command(const char *cmd, client_t *client,

--- a/client_command_handlers.h
+++ b/client_command_handlers.h
@@ -30,6 +30,8 @@ void cmd_set(command_args_t args, void (*response_cb)(client_t *client));
 
 void cmd_incr(command_args_t args, void (*response_cb)(client_t *client));
 
+void cmd_incr_by(command_args_t args, void (*response_cb)(client_t *client));
+
 void cmd_ping(command_args_t args, void (*response_cb)(client_t *client));
 
 void cmd_unknown(command_args_t args, void (*response_cb)(client_t *client));

--- a/command_defs.h
+++ b/command_defs.h
@@ -4,7 +4,7 @@
 #define CMD_SET 0x01
 #define CMD_GET 0x02
 #define CMD_INCR 0x03
-#define CMD_INCR_BY 0x03
-#define CMD_PING 0x04
+#define CMD_INCR_BY 0x04
+#define CMD_PING 0x05
 
 #endif // COMMAND_DEFS_H

--- a/server.conf
+++ b/server.conf
@@ -4,4 +4,4 @@ logs-enabled true
 verbose false
 daemonize false
 show-logo true
-unixsocket /tmp/fkvs.sock
+# unixsocket /tmp/fkvs.sock

--- a/server_command_handlers.c
+++ b/server_command_handlers.c
@@ -165,7 +165,7 @@ void handle_incr_command(int client_fd, unsigned char *buffer,
         return;
     }
 
-    const char one_str[] = "1";
+    const char *one_str = "1";
     char *result_str = add_strings(old_str, one_str);
     if (!result_str) {
         send_error(client_fd);


### PR DESCRIPTION
This PR fixes #10 

The culprit was found to be the command code which was the same for both commands. This is now fixed as INCR uses the 0x03 command code and INCR_BY uses the 0x04 command code.

Also, refactored some bits for consistency.