### PR TITLE
fix: generating the compile_commands.json file

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -83,7 +83,6 @@ jobs:
       - name: Generate compile commands json database
         run: > 
             cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=on
-            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
             -B ${{ steps.strings.outputs.build-output-dir }}
 
       - name: Install CodeChecker dependencies


### PR DESCRIPTION
If this PR is applied it will fix the issue causing the compile_commands.json not to be created. This file is needed during code analysis so we can get reports on issues in the code.