### PR TITLE
chore: fix compilation instructions for macos and ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ sudo apt install cmake
 
 cd deps/linenoise
 git submodule init
-git module update
+git submodule update
 cd ../../
 cmake .
 cmake --build .
@@ -63,7 +63,7 @@ brew install cmake
 
 cd deps/linenoise
 git submodule init
-git module update
+git submodule update
 cd ../../
 
 cmake .


### PR DESCRIPTION
This PR fixes a typo in the compilation instructions for MacOS and Ubuntu with git sub-modules.