### PR TITLE
chore: fix possible segfault when generating unique keys

### DIFF
--- a/src/commands/client/client_command_handlers.c
+++ b/src/commands/client/client_command_handlers.c
@@ -228,7 +228,7 @@ void execute_command_benchmark(const char *cmd, client_t *client,
              * and use them here so we don't spend too much of our benchmarking
              * time generating and formatting uuid keys as strings
              */
-            char key[512];
+            char key[KEY_LEN];
             generate_unique_key(key);
 
             binary_cmd = construct_set_command(key, "world", &cmd_len);


### PR DESCRIPTION
A possible segfault is happening when generating random keys during benchmark testing.

<img width="1132" height="88" alt="image" src="https://github.com/user-attachments/assets/b9855cdf-22c2-44a1-a14f-fc03c9e4fc6f" />

To be verified later with lldb (feel free to also do that and close the PR).