### PR TITLE
fix: ensure we display the correct server config file path

### DIFF
--- a/server.conf
+++ b/server.conf
@@ -1,5 +1,5 @@
 # Server configuration
-# port 5995
+port 5995
 logs-enabled true
 verbose false
 daemonize false
@@ -7,6 +7,6 @@ show-logo true
 # The event-loop-max-events  configuration defines the maximum number of events that
 # can be processed at one time during an iteration of the event loop
 event-loop-max-events 100000
-unixsocket /var/run/fkvs/fkvs.sock
+# unixsocket /var/run/fkvs/fkvs.sock
 # Enable io_uring for pro-reactive I/O handling on Linux
 use-io-uring true

--- a/src/config.c
+++ b/src/config.c
@@ -24,7 +24,7 @@ server_t load_server_config(const char *path)
     if (path) {
         server.config_file_path = path;
     } else {
-        server.config_file_path = DEFAULT_CLIENT_CONFIG_FILE_PATH;
+        server.config_file_path = DEFAULT_SERVER_CONFIG_FILE_PATH;
     }
 
     char line[1024];


### PR DESCRIPTION
If this PR is applied it will ensure we display the correct server config file path. Previously, it pointed to the client config instead of the servers config file path.

fixes #46 

<img width="808" height="631" alt="Screenshot 2025-11-12 at 6 41 36 PM" src="https://github.com/user-attachments/assets/50789699-1754-4b5b-8c05-74d73f73653a" />
