### PR TITLE
Fix memory corruption, use-after-free, and allocation bugs in set_value() and get_value()

### DIFF
--- a/src/core/hashtable.c
+++ b/src/core/hashtable.c
@@ -5,7 +5,8 @@
 #include <sys/time.h>
 
 // DJB2 hash function
-size_t hash_function(unsigned char *key, size_t key_len, size_t table_size)
+size_t hash_function(const unsigned char *key, const size_t key_len,
+                     const size_t table_size)
 {
     size_t hash = 5381;
     for (size_t i = 0; i < key_len; i++) {
@@ -15,7 +16,7 @@ size_t hash_function(unsigned char *key, size_t key_len, size_t table_size)
 }
 
 // Create a new hash table
-hashtable_t *create_hash_table(size_t size)
+hashtable_t *create_hash_table(const size_t size)
 {
     hashtable_t *table = malloc(sizeof(hashtable_t));
     table->buckets = calloc(size, sizeof(hash_table_entry_t *));
@@ -39,66 +40,130 @@ void free_hash_table(hashtable_t *table)
     free(table);
 }
 
-bool set_value(hashtable_t *table, unsigned char *key, size_t key_len,
-               void *value, size_t value_len, int value_type_encoding)
+bool set_value(const hashtable_t *table, const unsigned char *key, size_t key_len,
+               const void *value, size_t value_len, int value_type_encoding)
 {
     const size_t index = hash_function(key, key_len, table->size);
     hash_table_entry_t *current = table->buckets[index];
-    while (current != NULL && (current->key_len != key_len ||
-                               memcmp(current->key, key, key_len) != 0)) {
+    hash_table_entry_t *prev = NULL;
+
+    // Search for existing key
+    while (current != NULL &&
+          (current->key_len != key_len ||
+           memcmp(current->key, key, key_len) != 0))
+    {
+        prev = current;
         current = current->next;
     }
-    if (current == NULL) {
-        // New entry
-        current = malloc(sizeof(hash_table_entry_t));
+
+    const bool is_new_entry = (current == NULL);
+    if (is_new_entry) {
+        // Create entry
+        current = malloc(sizeof(*current));
+        if (!current) return false;
+
         current->key = malloc(key_len);
+        if (!current->key) {
+            free(current);
+            return false;
+        }
+
         memcpy(current->key, key, key_len);
         current->key_len = key_len;
+        current->value = NULL;
+
+        // Insert into bucket list
         current->next = table->buckets[index];
         table->buckets[index] = current;
-        free(current->key);
-    } else {
-        // Update existing entry
-        free(current->value->ptr);
     }
-    current->value = malloc(sizeof(value_entry_t));
-    current->value->ptr = malloc(value_len);
-    current->value->encoding = value_type_encoding;
-    memcpy(current->value->ptr, value, value_len);
-    current->value->value_len = value_len;
-    free(current->value->ptr);
-    free(current->value);
-    free(current);
+
+    // Prepare new value entry before touching old one
+    value_entry_t *new_val = malloc(sizeof(value_entry_t));
+    if (!new_val) {
+        if (is_new_entry) {
+            // Undo insertion
+            table->buckets[index] = current->next;
+            free(current->key);
+            free(current);
+        }
+        return false;
+    }
+
+    void *new_ptr = NULL;
+
+    if (value_len > 0) {
+        new_ptr = malloc(value_len);
+        if (!new_ptr) {
+            free(new_val);
+            if (is_new_entry) {
+                table->buckets[index] = current->next;
+                free(current->key);
+                free(current);
+            }
+            return false;
+        }
+        memcpy(new_ptr, value, value_len);
+    }
+
+    // Fill new value
+    new_val->ptr = new_ptr;
+    new_val->value_len = value_len;
+    new_val->encoding = value_type_encoding;
+
+    // We are now safe to free old value
+    if (!is_new_entry && current->value) {
+        free(current->value->ptr);
+        free(current->value);
+    }
+
+    current->value = new_val;
     return true;
 }
 
 bool get_value(hashtable_t *table, unsigned char *key, size_t key_len,
                value_entry_t **value, size_t *value_len)
 {
-    if (!table || !key || !value || !value_len)
+  if (!table || !key || !value || !value_len)
+    return false;
+
+  const size_t index = hash_function(key, key_len, table->size);
+
+  for (hash_table_entry_t *current = table->buckets[index];
+       current;
+       current = current->next)
+  {
+    if (current->key_len == key_len &&
+        memcmp(current->key, key, key_len) == 0)
+    {
+      // allocate full value_entry_t
+      value_entry_t *out = malloc(sizeof(value_entry_t));
+      if (!out)
         return false;
 
-    const size_t index = hash_function(key, key_len, table->size);
-    for (const hash_table_entry_t *current = table->buckets[index]; current;
-         current = current->next) {
-        if (current->key_len == key_len &&
-            memcmp(current->key, key, key_len) == 0) {
-            value_entry_t *out = malloc(sizeof(current->value));
-            if (!out)
-                return false; // allocation failed
+      // deep copy value bytes
+      out->ptr = malloc(current->value->value_len);
+      if (!out->ptr) {
+        free(out);
+        return false;
+      }
 
-            out->ptr = current->value->ptr;
-            out->encoding = current->value->encoding;
-            out->expirable = current->value->expirable;
-            out->type = current->value->type;
-            *value = out;
-            *value_len = current->value->value_len;
-            return true;
-        }
+      memcpy(out->ptr, current->value->ptr, current->value->value_len);
+
+      // copy metadata
+      out->value_len = current->value->value_len;
+      out->encoding  = current->value->encoding;
+      out->expirable = current->value->expirable;
+      out->type      = current->value->type;
+
+      *value = out;
+      *value_len = out->value_len;
+
+      return true;
     }
+  }
 
-    // not found
-    *value = NULL;
-    *value_len = 0;
-    return false;
+  *value = NULL;
+  *value_len = 0;
+  return false;
 }
+

--- a/src/core/hashtable.h
+++ b/src/core/hashtable.h
@@ -29,10 +29,10 @@ typedef struct hashtable {
 
 hashtable_t *create_hash_table(size_t size);
 void free_hash_table(hashtable_t *table);
-bool set_value(hashtable_t *table, unsigned char *key, size_t key_len,
-               void *value, size_t value_len, int value_type);
+bool set_value(const hashtable_t *table, const unsigned char *key, size_t key_len,
+               const void *value, size_t value_len, int value_type);
 bool get_value(hashtable_t *table, unsigned char *key, size_t key_len,
                value_entry_t **value, size_t *value_len);
-size_t hash_function(unsigned char *key, size_t key_len, size_t table_size);
+size_t hash_function(const unsigned char *key, size_t key_len, size_t table_size);
 
 #endif // HASHTABLE_H

--- a/src/string_utils.c
+++ b/src/string_utils.c
@@ -3,11 +3,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-char *to_upper(const char *string) {
-  char *result = malloc(strlen(string) + 1);
-  for (int i = 0; i < strlen(string); ++i) {
-    result[i] = toupper(string[i]);
-  }
-  result[strlen(string)] = '\0';
-  return result;
+char *to_upper(const char *string)
+{
+    char *result = malloc(strlen(string) + 1);
+    for (int i = 0; i < strlen(string); ++i) {
+        result[i] = toupper(string[i]);
+    }
+    result[strlen(string)] = '\0';
+    return result;
 }

--- a/tests/test_string_utils.c
+++ b/tests/test_string_utils.c
@@ -3,17 +3,19 @@
 #include <assert.h>
 #include <string.h>
 
-void test_string_utils_to_upper() {
+void test_string_utils_to_upper()
+{
     const char *string = "set";
-  assert(strcmp(to_upper(string), "SET") == 0);
+    assert(strcmp(to_upper(string), "SET") == 0);
 
-  const char *ping = "ping ";
-  assert(strcmp(to_upper(ping), "PING ") == 0);
+    const char *ping = "ping ";
+    assert(strcmp(to_upper(ping), "PING ") == 0);
 
-  const char *world = "WORLD";
-  assert(strcmp(to_upper(world), "WORLD") == 0);
+    const char *world = "WORLD";
+    assert(strcmp(to_upper(world), "WORLD") == 0);
 }
 
-int main(int argc, char *argv[]) {
-  test_string_utils_to_upper();
+int main(int argc, char *argv[])
+{
+    test_string_utils_to_upper();
 }


### PR DESCRIPTION
This PR fixes several severe memory-safety issues in our hash-table implementation.

Both set_value() and get_value() contained bugs capable of causing:
- heap corruption
- dangling pointers
- partial writes
- data loss
- crashes during normal operations
- 
This PR rewrites the critical sections to ensure correctness, atomicity, and safe memory ownership.
Key Fixes

Improvements to set_value()
- Ensures old values are only freed after new allocations succeed
- Fixes incorrect cleanup for new vs existing entries
- Fixes bucket corruption on value-allocation failure
- Prevents double-free conditions
- Adds zero-length value support
- Makes update logic fully atomic

Improvements to get_value()
- Corrects malloc(sizeof(pointer)) → malloc(sizeof(value_entry_t))
- Performs a deep copy of value bytes
- Removes use-after-free where out->ptr was freed before return
- Ensures safe error handling on allocation failures
- Prevents callers from mutating internal storage

What is the outcome of this?

After this PR:

SET is memory-safe, atomic, and predictable.
GET returns stable, independent values.
No dangling pointers, no double frees, no overwriting internal state.

Instruments reports clean behavior for all tested GET/SET patterns.

Testing

- Manual GET/SET/UPDATE sequences
- Instruments profiling with intensive workload

Verified correct behavior on updates, overwrites, and missing keys

Next Steps (Optional Future PRs)

- Add read-only zero-copy get_value_borrowed() for performance
- Consider migrating hashtable to Robin Hood hashing
- Add unit tests specifically targeting memory safety