### PR TITLE
chore: use https URL instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/linenoise"]
   path = deps/linenoise
-  url = git@github.com:AlexJuca/linenoise.git
+  url = https://github.com/AlexJuca/linenoise.git


### PR DESCRIPTION
This makes setup a tad bit easier in environments were ssh was not configured to talk to GitHub. 